### PR TITLE
add FK2026 page

### DIFF
--- a/content/posts/2026-04-17-forritunarkeppni-framhaldsskolanna-2026/index.mdx
+++ b/content/posts/2026-04-17-forritunarkeppni-framhaldsskolanna-2026/index.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Forritunarkeppni framhaldsskólanna 2026'
+date: '2026-04-17T13:30:00+00:00'
+slug: /2026/04/17/forritunarkeppni-framhaldsskolanna-2026/
+tags:
+    - 'Forritunarkeppni framhaldsskólanna'
+    - Keppnir
+---
+
+<figure>
+  ![](banner.png)
+</figure>
+
+## Efni
+
+- Dæmalýsingar 
+    - Alfa ([fyrir hádegi](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/blob/master/2026/pdf/fk_2026_alfa_fyrir.pdf), [eftir hádegi](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/blob/master/2026/pdf/fk_2026_alfa_eftir.pdf))
+    - Beta ([fyrir hádegi](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/blob/master/2026/pdf/fk_2026_beta_fyrir.pdf), [eftir hádegi](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/blob/master/2026/pdf/fk_2026_beta_eftir.pdf))
+    - Delta ([fyrir hádegi](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/blob/master/2026/pdf/fk_2026_delta_fyrir.pdf), [eftir hádegi](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/blob/master/2026/pdf/fk_2026_delta_eftir.pdf))
+- Lausnarglærur ([PDF](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/blob/master/2026/pdf/fk2026_solution_slides.pdf))
+- Lýsingar, lausnir og prófunartilvik ([GitHub](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir/tree/master/2026))
+- Heildarniðurstöður 
+    - Alfa ([HTML](https://iceland-fk26.kattis.com/contests/fk2026alfa/standings))
+    - Beta ([HTML](https://iceland-fk26.kattis.com/contests/fk2026beta/standings))
+    - Delta ([HTML](https://iceland-fk26.kattis.com/contests/fk2026delta/standings))


### PR DESCRIPTION
todo
* [ ] banner?
 * gætum mögulega notað [þetta](https://github.com/ForritunarkeppniFramhaldsskolanna/FK2026/blob/main/docs/slides/solution/fk2026_slide.jpg) sem banner eða bara slept því að hafa banner (note: þarft að vera partur af dæmagerð fyrir fk2026 til að geta séð mynd]
* [ ] bæta við FK2026 í [public keppnir](https://github.com/ForritunarkeppniFramhaldsskolanna/Keppnir) repo og laga links ef þarf
  * [ ] Lausnarglærur
  * [ ] Github link
  * [ ] Alfa Dæmalýsingar
    * [ ]  fyrir hádegi
    * [ ] eftir hádegi
  * [ ] Beta Dæmalýsingar
    * [ ]  fyrir hádegi
    * [ ] eftir hádegi
  * [ ] Delta Dæmalýsingar
    * [ ]  fyrir hádegi
    * [ ] eftir hádegi